### PR TITLE
UHF-X: Small fixes to email template texts

### DIFF
--- a/src/bin/hav-populate-email-queue.ts
+++ b/src/bin/hav-populate-email-queue.ts
@@ -139,7 +139,6 @@ const app = async (): Promise<{}> => {
         search_description: subscription.search_description,
         search_link: subscription.query,
         remove_link: '?subscription=' + subscription._id + '&hash=' + subscription.hash,
-        num_hits: newHits.length,
         hits: newHits
       })
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -59,8 +59,7 @@ export const newHitsEmail = async (lang: SubscriptionCollectionLanguageType, dat
   search_description: string,
   search_link: string,
   remove_link: string,
-  created_date: string,
-  num_hits: number }) => {
+  created_date: string }) => {
   try {
     const hitsContent = data.hits.map(item => sprightly('dist/templates/link_text.html', {
       link: baseUrl + item.url,

--- a/src/templates/rekry/newhits_en.html
+++ b/src/templates/rekry/newhits_en.html
@@ -9,7 +9,7 @@
 </head>
 
 <body style="margin:0;padding:0;">
-  <p>We found {{ num_hits }} new matches for your saved search. Search criteria: {{ search_description }}, {{ created_date }}</p>
+  <p>We found new matches for your saved search. Search criteria: {{ search_description }}, {{ created_date }}</p>
   <p></p>
   {{ hits }}
   <p></p>

--- a/src/templates/rekry/newhits_fi.html
+++ b/src/templates/rekry/newhits_fi.html
@@ -9,7 +9,7 @@
 </head>
 
 <body style="margin:0;padding:0;">
-  <p>Löysimme {{ num_hits }} uutta osumaa hakuvahdillasi. Hakuehdot: {{ search_description }}, {{ created_date }}</p>
+  <p>Löysimme uusia osumia hakuvahdillasi. Hakuehdot: {{ search_description }}, {{ created_date }}</p>
   <p></p>
   {{ hits }}
   <p></p>

--- a/src/templates/rekry/newhits_sv.html
+++ b/src/templates/rekry/newhits_sv.html
@@ -9,7 +9,7 @@
 </head>
 
 <body style="margin:0;padding:0;">
-  <p>Vi hittade {{ num_hits }} nya träffar med din sökvakt. Sökvillkor: {{ search_description }}, {{ created_date }}</p>
+  <p>Vi hittade nya träffar med din sökvakt. Sökvillkor: {{ search_description }}, {{ created_date }}</p>
   <p></p>
   {{ hits }}
   <p></p>


### PR DESCRIPTION
Changes newhits templates intro text to a common sentence without hit numbers.