### PR TITLE
Add /healthz and /readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ Subscriptions that are not confirmed, will not be checked during `npm run hav:po
 
 Deletes a subscription. To delete a subscription, user must know both the id and hash (`hash` field in collection).
 
+## Health checks
+
+Hakuvahti includes OpenShift compatible endpoints for health check:
+
+`/healthz` Returns 200 OK and confirms Hakuvahti server is running.
+
+`/readiness` Returns 200 OK and confirms Hakuvahti server is running and MongoDB connection is working.
+
 ## Command line / cron actions
 
 ### Initialize MongoDB collections

--- a/src/plugins/token.ts
+++ b/src/plugins/token.ts
@@ -4,6 +4,11 @@ import fp from 'fastify-plugin'
 
 export default fp(async (fastify, opts) => {
   fastify.addHook('preHandler', async (request, reply) => {
+    // Skip token check for health check routes
+    if (request.url === '/healthz' || request.url === '/readiness') {
+      return true
+    }
+
     if (!request.headers.token) {
       reply
         .code(403)
@@ -11,9 +16,9 @@ export default fp(async (fastify, opts) => {
         .send({ error: 'Authentication failed.'})
     }
 
-    // TODO: Token auth / check.
+    // TODO: Do something with the token
 
-    return true;
+    return true
   })
 })
 

--- a/src/routes/healthzAndReadiness.ts
+++ b/src/routes/healthzAndReadiness.ts
@@ -9,8 +9,6 @@ const healthzAndReadiness: FastifyPluginAsync = async (
   fastify: FastifyInstance,
   opts: object
 ): Promise<void> => {
-
-  // /healthz route
   fastify.get('/healthz', {
     schema: {
       response: {
@@ -33,10 +31,9 @@ const healthzAndReadiness: FastifyPluginAsync = async (
       .send({
         statusCode: 200,
         message: 'OK'
-      });
-  });
+      })
+  })
 
-  // /readiness route
   fastify.get('/readiness', {
     schema: {
       response: {
@@ -73,16 +70,16 @@ const healthzAndReadiness: FastifyPluginAsync = async (
         .send({
           statusCode: 200,
           message: 'OK'
-        });
+        })
     } catch (error) {
       return reply
         .code(500)
         .send({
           statusCode: 500,
           message: 'MongoDB connection failed'
-        });
+        })
     }
-  });
-};
+  })
+}
 
 export default healthzAndReadiness;

--- a/src/routes/healthzAndReadiness.ts
+++ b/src/routes/healthzAndReadiness.ts
@@ -1,0 +1,88 @@
+import {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyInstance,
+  FastifyRequest
+} from 'fastify';
+
+const healthzAndReadiness: FastifyPluginAsync = async (
+  fastify: FastifyInstance,
+  opts: object
+): Promise<void> => {
+
+  // /healthz route
+  fastify.get('/healthz', {
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            statusCode: { type: 'number' },
+            message: { type: 'string' }
+          },
+          required: ['statusCode', 'message']
+        }
+      }
+    }
+  }, async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => {
+    return reply
+      .code(200)
+      .send({
+        statusCode: 200,
+        message: 'OK'
+      });
+  });
+
+  // /readiness route
+  fastify.get('/readiness', {
+    schema: {
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            statusCode: { type: 'number' },
+            message: { type: 'string' }
+          },
+          required: ['statusCode', 'message']
+        },
+        500: {
+          type: 'object',
+          properties: {
+            statusCode: { type: 'number' },
+            message: { type: 'string' }
+          },
+          required: ['statusCode', 'message']
+        }
+      }
+    }
+  }, async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ) => {
+    const mongodb = fastify.mongo;
+
+    try {
+      // Check MongoDB connection
+      await mongodb.db?.command({ ping: 1 });
+
+      return reply
+        .code(200)
+        .send({
+          statusCode: 200,
+          message: 'OK'
+        });
+    } catch (error) {
+      return reply
+        .code(500)
+        .send({
+          statusCode: 500,
+          message: 'MongoDB connection failed'
+        });
+    }
+  });
+};
+
+export default healthzAndReadiness;


### PR DESCRIPTION
Adds /healthz and /readiness endpoints that Openshift wants for health checks.

/healthz returns 200 ok when server is up, /readiness returns 200 ok when server is up and mongodb connection is working