### PR TITLE
Running just npm run build:ts + cli script in a fresh installation wi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "npm run build:ts && npm run copy:assets && npm run hav:init-mongodb && fastify start -l info dist/app.js",
     "build:ts": "npm run copy:assets; tsc",
     "watch:ts": "npm run copy:assets; tsc -w",
-    "copy:assets": "cp -R src/templates dist/",
+    "copy:assets": "mkdir dist; cp -R src/templates dist/",
     "dev": "npm run copy:assets; npm run build:ts && npm run hav:init-mongodb && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"npm:dev:start\"",
     "dev:start": "npm run copy:assets; fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
     "info": "fastify print-routes ./routes/root.ts",


### PR DESCRIPTION
…ll fail to copy mail template files in dist/ directory because cp behaves differently whether or not directory is existing.

If it is not existing (like in case of just running build:ts instead of dev/start), command "cp -R src/templates dist/" will make templates copy under dist/ root  (not desired), but if the directory exists when running the command, the templates will end up in dist/templates directory as they should.