### PR TITLE
UHF-10329: Replace console.logs with proper error logging

### DIFF
--- a/src/bin/hav-populate-email-queue.ts
+++ b/src/bin/hav-populate-email-queue.ts
@@ -53,7 +53,7 @@ const massDeleteSubscriptions = async (modifyStatus: SubscriptionStatus, olderTh
     try {
       await collection.deleteMany({ status: modifyStatus, created: { $lt: dateLimit } })
     } catch (error) {
-      console.log(error)
+      console.error(error)
 
       throw new Error('Could not delete subscriptions. See logs for errors.')
     }

--- a/src/bin/hav-send-emails-in-queue.ts
+++ b/src/bin/hav-send-emails-in-queue.ts
@@ -81,7 +81,7 @@ const app = async (): Promise<{}> => {
             html: email.content
           }, (errors, info) => {
             if (errors) {
-              console.log(errors);
+              console.error(errors);
 
               throw Error('Sending email failed. See logs');
             }

--- a/src/plugins/atv.ts
+++ b/src/plugins/atv.ts
@@ -30,7 +30,7 @@ const atvFetchContentById = async (atvDocumentId: string): Promise<Partial<AtvDo
       throw new Error('Empty content returned from API')
     }
   } catch (error: unknown) {
-    console.log(error);
+    console.error(error);
 
     throw new Error('Error fetching Document by id')
   }
@@ -75,7 +75,7 @@ const atvCreateDocumentWithEmail = async (email: string): Promise<Partial<AtvDoc
 
     return response.data;
   } catch (error: unknown) {
-    console.log(error)
+    console.error(error)
 
     throw new Error('Failed to create document. See error log.')
   }
@@ -106,7 +106,7 @@ const atvGetDocumentBatch = async (emails: string[]): Promise<Partial<AtvDocumen
 
     return response.data
   } catch (error: any) {
-    console.log(error)
+    console.error(error)
 
     throw new Error('Failed to fetch document. See error log.')
   }

--- a/src/routes/addSubscription.ts
+++ b/src/routes/addSubscription.ts
@@ -69,7 +69,7 @@ const subscription: FastifyPluginAsync = async (
     const response = await collection?.insertOne(subscription)
     if (!response) {
       fastify.log.debug(response)
-      console.log(response)
+
       throw new Error('Adding new subscription failed. See logs.')
     }
     
@@ -89,7 +89,7 @@ const subscription: FastifyPluginAsync = async (
     const q = mongodb.db?.collection('queue')
     await q?.insertOne(email)
 
-    console.log(emailContent)
+    fastify.log.debug(emailContent)
 
     return reply
       .code(200)


### PR DESCRIPTION
- Use fastify.log.debug() in public route instead of console.log
- Use console.error instead of console.log()

Production builds don't print out these.