### PR TITLE
UHF-11521 Cron monitoring

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,8 +14,6 @@ const app: FastifyPluginAsync<AppOptions> = async (
     fastify,
     opts
 ): Promise<void> => {
-  const release = new Date()
-
   if (process.env.ENVIRONMENT === undefined) {
     throw new Error('ENVIRONMENT environment variable is not set')
   }
@@ -26,10 +24,11 @@ const app: FastifyPluginAsync<AppOptions> = async (
     throw new Error('ENVIRONMENT environment variable is not valid')
   }
 
+  const release = process.env.SENTRY_RELEASE ?? '';
   fastify.register(require('@immobiliarelabs/fastify-sentry'), {
     dsn: process.env.SENTRY_DSN,
     environment: env,
-    release: release.toISOString().substring(0, 10),
+    release: release,
     setErrorHandler: true
   })
 

--- a/src/bin/hav-populate-email-queue.ts
+++ b/src/bin/hav-populate-email-queue.ts
@@ -16,13 +16,12 @@ import { QueueInsertDocumentType } from '../types/mailer'
 dotenv.config()
 
 const server = fastify({})
-
-const release = new Date()
+const release = process.env.SENTRY_RELEASE ?? '';
 
 server.register(require('@immobiliarelabs/fastify-sentry'), {
   dsn: process.env.SENTRY_DSN,
   environment: process.env.ENVIRONMENT,
-  release: release.toISOString().substring(0, 10),
+  release: release,
   setErrorHandler: true
 })
 
@@ -201,6 +200,7 @@ const app = async (): Promise<{}> => {
     server.Sentry?.captureException(error)
   }
 
+  server.Sentry.captureCheckIn({monitorSlug: 'hav-populate-email-queue', status: 'ok'})
   return {}
 };
 

--- a/src/bin/hav-send-emails-in-queue.ts
+++ b/src/bin/hav-send-emails-in-queue.ts
@@ -15,7 +15,7 @@ const release = process.env.SENTRY_RELEASE ?? '';
 server.register(require('@immobiliarelabs/fastify-sentry'), {
   dsn: process.env.SENTRY_DSN,
   environment: process.env.ENVIRONMENT,
-  release: release, // release.toISOString().substring(0, 10),
+  release: release,
   setErrorHandler: true
 })
 

--- a/src/bin/hav-send-emails-in-queue.ts
+++ b/src/bin/hav-send-emails-in-queue.ts
@@ -10,13 +10,12 @@ import { ObjectId } from '@fastify/mongodb';
 dotenv.config()
 
 const server = fastify({})
-
-const release = new Date()
+const release = process.env.SENTRY_RELEASE ?? '';
 
 server.register(require('@immobiliarelabs/fastify-sentry'), {
   dsn: process.env.SENTRY_DSN,
   environment: process.env.ENVIRONMENT,
-  release: release.toISOString().substring(0, 10),
+  release: release, // release.toISOString().substring(0, 10),
   setErrorHandler: true
 })
 
@@ -26,7 +25,6 @@ void server.register(mongodb)
 void server.register(atv)
 
 // Command line/cron application to send all emails from queue collection
-
 const BATCH_SIZE = 100
 
 const app = async (): Promise<{}> => {
@@ -115,6 +113,7 @@ const app = async (): Promise<{}> => {
     }
   }
 
+  server.Sentry.captureCheckIn({monitorSlug: 'hav-send-emails-in-queue', status: 'ok'})
   return {}
 }
 


### PR DESCRIPTION
# [UHF-11521](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11521)

## What was done
- Added sentry-cron-monitoring requests to both cron-based features
- Extra: fixed the sentry "release" variable

## How to install
* Don't know if rekry should be up and running
  * Run the indexing just in case 

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11521`
  * Add hakuvahti´s sentry-dsn to hakuvahti .env file 
  * `make up`


## How to test
Remember to add the hakuvahti test-sentry dsn to .env-file^
- Go to test-sentry and [enable both monitors](https://sentry.test.hel.ninja/organizations/city-of-helsinki/crons).
- Go to the node-container and manually run both populate-email-queue and send-emails
  - `npm run hav:populate-email-queue`
  - `npm run hav:send-emails-in-queue`
- See that sentry managed to catch the monitoring messages
  - populate-queue should trigger warning after 3 minutes. send-email should trigger warning after 13 minutes
  - Both cases should create issues for hakuvahti-project
  - Rememeber to disable the cron monitors after testing .
- Go to [production sentry](https://sentry.hel.fi/organizations/city-of-helsinki/crons) and see that the cron monitors exist and are properly configured.

- Go and check the hakuvahti environment variables
  - There should be new SENTRY_RELEASE  variables set up properly.


[UHF-10889]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-11521]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ