### PR TITLE
UHF-12058: Filter out email from Sentry errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,22 @@ const app: FastifyPluginAsync<AppOptions> = async (
   const release = process.env.SENTRY_RELEASE ?? '';
   fastify.register(require('@immobiliarelabs/fastify-sentry'), {
     dsn: process.env.SENTRY_DSN,
+    beforeSend: (event: any) => {
+      if (!event?.request?.data) {
+        return event;
+      }
+      
+      const data = JSON.parse(event.request.data);
+
+      if (!data.email) {
+        return event;
+      }
+
+      delete data.email;
+      event.request.data = JSON.stringify(data);
+
+      return event;
+    },
     environment: env,
     release: release,
     setErrorHandler: true


### PR DESCRIPTION
# [UHF-12058](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12058)

Implement Sentry's `beforeSend` hook to filter out sensitive info from logs.

##  How to test

* Set up the environment following the README
* Set the `SENTRY_DSN` value in `.env`. Get the key here: https://sentry.test.hel.ninja/settings/city-of-helsinki/projects/helfi-rekry-hakuvahti/keys/
* Once you have the app running send a POST request to `/subscribe` endpoint
  * Use this as the body: 
```
  {
    "elastic_query": "eyJhZ2dzIjp7ImZpZWxkX2pvYnMiOnsic3VtIjp7ImZpZWxkIjoiZmllbGRfam9icyIsIm1pc3NpbmciOjF9fSwidG90YWxfY291bnQiOnsiY2FyZGluYWxpdHkiOnsiZmllbGQiOiJmaWVsZF9yZWNydWl0bWVudF9pZC5rZXl3b3JkIn19fSwiY29sbGFwc2UiOnsiZmllbGQiOiJmaWVsZF9yZWNydWl0bWVudF9pZC5rZXl3b3JkIiwiaW5uZXJfaGl0cyI6eyJuYW1lIjoidHJhbnNsYXRpb25zIiwic2l6ZSI6M319LCJmcm9tIjowLCJxdWVyeSI6eyJib29sIjp7ImZpbHRlciI6W3sidGVybSI6eyJlbnRpdHlfdHlwZSI6Im5vZGUifX1dLCJtdXN0IjpbeyJib29sIjp7Im11c3Rfbm90Ijp7InRlcm0iOnsiZmllbGRfcHJvbW90ZWQiOnRydWV9fX19XX19LCJzb3J0IjpbeyJmaWVsZF9wdWJsaWNhdGlvbl9zdGFydHMiOnsib3JkZXIiOiJkZXNjIn19LCJfc2NvcmUiXSwic2l6ZSI6MzB9",
    "search_description": "Ei hakuehtoja",
    "query": "/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja",
    "email": "test@testfi",
    "lang": "fi"
}
```
* Sending the request should log an error to Sentry. Check the issue. A little way down the page you should see "Body" section showing the request payload. This should omit the email value that you sent.
  * Example of a logged error with email omitted: https://sentry.test.hel.ninja/organizations/city-of-helsinki/issues/26109/?query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0

[UHF-12058]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ