### PR TITLE
UHF-13281: Add flush with 2sec timeout to make sure sentry sends errors/checkins

### DIFF
--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -50,6 +50,7 @@ export default function command(app: Command, plugins: Array<(...args: any[]) =>
       console.error('Command failed', err);
     }
 
+    await server.Sentry?.flush(2000);
     await server.close();
 
     // Exit with failure if command failed.


### PR DESCRIPTION
* Sentry misses checkIns in production for some reason, but not always. 
* I suspect async problem with long running scripts, so force flush before server.close()