### PR TITLE
UHF-13133: fix inverse dryRun check on sms

### DIFF
--- a/src/bin/hav-populate-queue.ts
+++ b/src/bin/hav-populate-queue.ts
@@ -332,7 +332,6 @@ const processSiteSubscriptions = async (
           };
 
           if (!isDryRun) {
-          } else {
             await queueCollection.insertOne(smsToQueue);
           }
           stats.smsQueued++;


### PR DESCRIPTION
* Dry run check in sms expiry notification was inverse, making them get dropped silently in production.