### PR TITLE
UHF-12826: Force light mode to fix dark mode weirdness

### DIFF
--- a/src/templates/etusivu/index.html
+++ b/src/templates/etusivu/index.html
@@ -4,8 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="x-apple-disable-message-reformatting">
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
     <title>{{ title }}</title>
     <style>
+      :root { color-scheme: light; }
+
       @media only screen and (max-width: 600px) {
         .header-branding td.stack-column {
           display: block !important;
@@ -23,7 +27,7 @@
       }
     </style>
   </head>
-  <body style="font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
+  <body style="background-color: #ffffff; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
       <tr>
         <td align="center">

--- a/src/templates/kymp/index.html
+++ b/src/templates/kymp/index.html
@@ -4,8 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="x-apple-disable-message-reformatting">
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
     <title>{{ title }}</title>
     <style>
+      :root { color-scheme: light; }
+
       @media only screen and (max-width: 600px) {
         .header-branding td.stack-column {
           display: block !important;
@@ -23,7 +27,7 @@
       }
     </style>
   </head>
-  <body style="font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
+  <body style="background-color: #ffffff; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
       <tr>
         <td align="center">

--- a/src/templates/rekry/index.html
+++ b/src/templates/rekry/index.html
@@ -4,8 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="x-apple-disable-message-reformatting">
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
     <title>{{ title }}</title>
     <style>
+      :root { color-scheme: light; }
+
       @media only screen and (max-width: 600px) {
         .header-branding td.stack-column {
           display: block !important;
@@ -23,7 +27,7 @@
       }
     </style>
   </head>
-  <body style="font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
+  <body style="background-color: #ffffff; font-family: Arial, Helvetica, sans-serif; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse; margin-bottom: 0; margin-left: auto; margin-right: auto; margin-top: 0; padding-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0;">
       <tr>
         <td align="center">


### PR DESCRIPTION
* Email clients in dark mode were overriding template colors due to no explicit background color on `<body>`
* Added `color-scheme` meta tags and `:root { color-scheme: light; }` for modern clients (Apple Mail etc.)
* Added `background-color: #ffffff` inline on `<body>` for older clients that strip `<style>` blocks (e.g. Gmail)

**How to test**

* Run `npm run hav:test-all-templates -- --email=test@test.fi` and check them in mailpit. Mailpit allows downloading .eml raw messages. Import to any client capable of importing .eml messages or check the source for added body/css tags.
